### PR TITLE
Proposal Changing empty for nil as is not possible to filter empty values

### DIFF
--- a/lib/seeker/query/predicates.ex
+++ b/lib/seeker/query/predicates.ex
@@ -5,7 +5,7 @@ defmodule Seeker.Query.Predicates do
 
   import Ecto.Query, warn: false
 
-  def call(scope, {_association, _column, _predicate}, ""), do: scope
+  def call(scope, {_association, _column, _predicate}, nil), do: scope
 
   def call(scope, {association, column, :eq}, value) do
     scope |> where([{^association, table}], field(table, ^column) == ^value)

--- a/test/seeker_test.exs
+++ b/test/seeker_test.exs
@@ -7,11 +7,11 @@ defmodule SeekerTest do
   alias Seeker.Schemas.{Category, Post}
 
   describe "all/2" do
-    test "ignores value when it is empty" do
+    test "ignores value when value is nil" do
       {:ok, category1} = Repo.insert(%Category{name: "Foo"})
       {:ok, category2} = Repo.insert(%Category{name: "Bar"})
 
-      params = %{q: %{name_eq: ""}}
+      params = %{q: %{name_eq: nil}}
       results = SeekerApp.all(Category, params)
       assert results == [category1, category2]
     end


### PR DESCRIPTION
Tried doing 
`      params = %{q: %{name_eq: ""}}`
and is ignored, i believe it should be better to send nil. 

Either that or may be create an "empty" predicate

